### PR TITLE
fix(themes): fix a glitch when loading the page

### DIFF
--- a/.stylelintrc.yaml
+++ b/.stylelintrc.yaml
@@ -274,15 +274,14 @@ rules:
       - each
       - else
       - error
+      - extend
       - for
       - function
-      - include
       - if
+      - include
       - mixin
       - return
       - warn
-  at-rule-blacklist:
-    - extend
   property-no-unknown:
     - true
     - ignoreProperties:

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -5,23 +5,33 @@ $text: var(--text);
 $inverted-text: var(--inverted-text);
 $header-link: var(--header-link);
 
+%dark {
+  --accent: #efbb35;
+  --background: #11151c;
+  --primary: #192734;
+  --text: #f8f8f8;
+  --inverted-text: var(--text);
+  --header-link: var(--text);
+}
+
+%light {
+  --accent: #23b5d3;
+  --background: #fbfef9;
+  --primary: #071013;
+  --text: #284b63;
+  --inverted-text: var(--background);
+  --header-link: var(--inverted-text);
+}
+
 body {
+  @extend %dark;
+
   &.dark {
-    --accent: #efbb35;
-    --background: #11151c;
-    --primary: #192734;
-    --text: #f8f8f8;
-    --inverted-text: var(--text);
-    --header-link: var(--text);
+    @extend %dark;
   }
 
   &.light {
-    --accent: #23b5d3;
-    --background: #fbfef9;
-    --primary: #071013;
-    --text: #284b63;
-    --inverted-text: var(--background);
-    --header-link: var(--inverted-text);
+    @extend %light;
 
     @include print {
       --background: #fff;


### PR DESCRIPTION
When loading the page, before setting light or dark mode, there were a few seconds when no color variable was defined, resulting in a kind of white flash.